### PR TITLE
Add app.json and Deploy to Heroku button

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,13 @@ This is a Go app which takes Heroku Log drains and parses the router and dyno in
 
 Create a db, user and password, and write the details + hostname and port down.
 
-### Install on Heroku
+### Deploy to Heroku
+
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
+### Add the drain to an app
+
 ```
-heroku create -b https://github.com/kr/heroku-buildpack-go.git <lumbermill_app>
-heroku config:set INFLUXDB_HOSTS="<host:port>" \
-                  INFLUXDB_USER="<user>" \
-                  INFLUXDB_PWD="<password>" \
-                  INFLUXDB_NAME="<dbname>" \
-                  INFLUXDB_SKIP_VERIFY=true
-
-
-git push heroku master
-
 heroku drains:add https://<lumbermill_app>.herokuapp.com/drain --app <the-app-to-mill-for>
 ```
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,32 @@
+{
+    "name": "Lumbermill",
+    "description": "Go app which takes Heroku Log drains and parses the router and dyno information, and then pushes metrics to influxdb",
+    "website": "https://github.com/heroku/lumbermill",
+    "repository": "https://github.com/heroku/lumbermill",
+    "keywords": [
+        "logs",
+        "drain",
+        "InfluxDB",
+        "golang"
+    ],
+    "success_url": "https://github.com/heroku/lumbermill#add-the-drain-to-an-app",
+    "env": {
+        "BUILDPACK_URL": "https://github.com/kr/heroku-buildpack-go.git",
+        "INFLUXDB_HOSTS": {
+            "description": "InfluxDB host:port"
+        },
+        "INFLUXDB_USER": {
+            "description": "InfluxDB username"
+        },
+        "INFLUXDB_PWD": {
+            "description": "InfluxDB password"
+        },
+        "INFLUXDB_NAME": {
+            "description": "InfluxDB database name"
+        },
+        "INFLUXDB_SKIP_VERIFY": {
+            "description": "Disable InfluxDB TLS verification",
+            "value": "true"
+        }
+    }
+}


### PR DESCRIPTION
_I realize this may not be the best project for a Deploy to Heroku button, so feel free to ignore/close this. I was mostly just playing around to test something out and figured I might as well offer it as a contribution._

This adds an [`app.json` manifest](https://devcenter.heroku.com/articles/app-json-schema) and a [Deploy to Heroku button](https://devcenter.heroku.com/articles/heroku-button) to the readme that simplifies the existing setup instructions.
