### PR TITLE
Allow influxDB without SSL

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func createInfluxDBClient(host string, f clientFunc) influx.ClientConfig {
 		Username:   os.Getenv("INFLUXDB_USER"), //"test",
 		Password:   os.Getenv("INFLUXDB_PWD"),  //"tester",
 		Database:   os.Getenv("INFLUXDB_NAME"), //"ingress",
-		IsSecure:   true,
+		IsSecure:   os.Getenv("INFLUXDB_INSECURE") != "true",
 		HttpClient: f(),
 	}
 }


### PR DESCRIPTION
For certain cases (i.e. spiking / prototyping), standing up
influxor without any SSL might make sense.

If that's the shape of the influx cluster, then we simply
have to configure lumbermill to do INFLUXDB_INSECURE=true
for it to talk over http instead of https.